### PR TITLE
Fixed wrong info in recipe

### DIFF
--- a/recipes/use-url-parameters-to-filter-or-sort-data.md
+++ b/recipes/use-url-parameters-to-filter-or-sort-data.md
@@ -9,7 +9,7 @@ How can you pass parameters in the URL to filter data when requesting a collecti
 Answer
 ------
 
-`Collection Query String whitelist` under `Content Negotiation` in the Admin UI, or its analogue
+`Collection Query String whitelist` under `REST Parameters` in the Admin UI, or its analogue
 `collection_query_whitelist` key within `zf-rest` in `module.config.php`, whitelists query string
 arguments, allowing their value to be received by your REST resource's `fetchAll($params = array())`
 method.


### PR DESCRIPTION
The recipe mentions "Content Negotiation" but in the actual UI the "Collection Query String whitelist" is under "REST Parameters" instead.
